### PR TITLE
Quick fix to join_nearest_distance docs

### DIFF
--- a/R/ranges-join-nearest.R
+++ b/R/ranges-join-nearest.R
@@ -3,10 +3,9 @@
 #' @param x,y Ranges objects, add the nearest neighbours of ranges in x to
 #' those in y.
 #' @param suffix A character vector of length two used to identify metadata columns
-#' @param distance logical vector whether to add "distance" column to output. If set to
-#'   a character vector of length 1, will use that as distance column name. If a
-#'   column matching the distance column already exits, will prepend the suffix
-#'   for y with a warning.
+#' @param distance logical vector whether to add a column named "distance"
+#'   containing the distance to the nearest region. If set to a character vector
+#'   of length 1, will use that as distance column name.
 #'
 #' @details By default `join_nearest` will find arbitrary nearest
 #' neighbours in either direction and ignore any strand information.

--- a/man/plyranges-package.Rd
+++ b/man/plyranges-package.Rd
@@ -44,7 +44,7 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Stuart Lee \email{lee.s@wehi.edu.au}
+\strong{Maintainer}: Stuart Lee \email{lee.s@wehi.edu.au} (\href{https://orcid.org/0000-0003-1179-8436}{ORCID})
 
 Authors:
 \itemize{

--- a/man/ranges-nearest.Rd
+++ b/man/ranges-nearest.Rd
@@ -24,10 +24,9 @@ those in y.}
 
 \item{suffix}{A character vector of length two used to identify metadata columns}
 
-\item{distance}{logical vector whether to add "distance" column to output. If set to
-a character vector of length 1, will use that as distance column name. If a
-column matching the distance column already exits, will prepend the suffix
-for y with a warning.}
+\item{distance}{logical vector whether to add a column named "distance"
+containing the distance to the nearest region. If set to a character vector
+of length 1, will use that as distance column name.}
 }
 \value{
 A Ranges object corresponding to the nearest ranges, all metadata


### PR DESCRIPTION
I forgot to remove the bit about appending a suffix from the join_nearest distance argument docs. This removes that sentence.