### PR TITLE
suggestion for anchor default text

### DIFF
--- a/vignettes/an-introduction.Rmd
+++ b/vignettes/an-introduction.Rmd
@@ -79,6 +79,8 @@ This is achieved with the `mutate` verb along with `anchor_*` adverbs.
 The act of anchoring fixes either the start, end, center coordinates of the
 `Range` object, as shown in the figure and code below and anchors are used in
 combination with either `mutate` or `stretch`.
+By default, the start coordinate will be anchored, so regardless of strand. 
+For behavior similar to `GenomicRanges::resize`, use `anchor_5p`.
 
 ```{r anchor_fig, echo = FALSE, out.width="400px", fig.align="center"}
 knitr::include_graphics("anchors.png", dpi = 150)


### PR DESCRIPTION
Just some suggested text to link behavior of `mutate` and that of `resize` to be clear about what happens without explicit anchoring.

Also, the negative coordinates are a little confusing, maybe shift the example by 100 to avoid negative coordinates?