### PR TITLE
remove mention of UCSC, as this has changed/not always applicable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,7 @@ Suggests:
     ggplot2
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.2.3
 Collate: 
     'class-AnchoredRanges.R'
     'class-Operator.R'

--- a/R/ranges-genomeinfo.R
+++ b/R/ranges-genomeinfo.R
@@ -18,8 +18,6 @@ genome_info <- function(genome = NULL, seqnames = NULL, seqlengths = NULL, is_ci
 #'
 #' @param .data A Ranges object to annotate or retrieve an annotation for.
 #' @param genome A character vector of length one indicating the genome build.
-#' If this is the only argument supplied, the build information will be
-#' retrieved from UCSC database.
 #' @param seqnames A character vector containing the name of sequences.
 #' @param seqlengths An optional integer vector containg the lengths of sequences.
 #' @param is_circular An optional logical vector indicating whether a sequence is ciruclar.
@@ -28,13 +26,12 @@ genome_info <- function(genome = NULL, seqnames = NULL, seqlengths = NULL, is_ci
 #' as a Ranges object use `get_genome_info`.
 #'
 #' @description To construct annotations by supplying annotation information
-#' use `genome_info`. This function allows you to get UCSC build information
-#' via [GenomeInfoDb::fetchExtendedChromInfoFromUCSC()]. To add
+#' use `genome_info`. To add
 #' annotations to an existing Ranges object use `set_genome_info`. To retrieve
 #' an annotation as a Ranges object use `get_genome_info`.
 #'
 #' @importFrom GenomeInfoDb Seqinfo seqnames seqlengths isCircular genome seqinfo
-#' @seealso [GenomeInfoDb::Seqinfo()], [GenomeInfoDb::fetchExtendedChromInfoFromUCSC()]
+#' @seealso [GenomeInfoDb::Seqinfo()]
 #' @examples
 #' x <- genome_info(genome = "toy",
 #'                  seqnames = letters[1:4],

--- a/R/ranges-reduce.R
+++ b/R/ranges-reduce.R
@@ -35,9 +35,10 @@ reduce_single <- function(.data, ..., rfun = reduce) {
   if (length(dots) == 0L) {
     return(rfun(.data))
   }
+
   reduced <- rfun(.data, with.revmap = TRUE)
   
-  .data <- group_by_revmap(.data, 
+  .data <- group_by_revmap(.data,
                            mcols(reduced)[["revmap"]],
                            make_revmap_rle(mcols(reduced)[["revmap"]]))
   
@@ -78,6 +79,7 @@ reduce_by_grp <- function(.data, ..., rfun = IRanges::reduce) {
 #' Reduce then aggregate a Ranges object
 #'
 #' @param .data a Ranges object to reduce
+#' @param min.gapwidth Ranges separated by a gap of at least min.gapwidth positions are not merged. 
 #' @param ... Name-value pairs of summary functions.
 #'
 #' @return a Ranges object with the
@@ -106,60 +108,65 @@ reduce_by_grp <- function(.data, ..., rfun = IRanges::reduce) {
 #' x %>% reduce_ranges(score = sum(score))
 #' x %>% group_by(id) %>% reduce_ranges(score = sum(score))
 #' @export
-reduce_ranges <- function(.data, ...) { UseMethod("reduce_ranges") }
+reduce_ranges <- function(.data, min.gapwidth = 1L, ...) { UseMethod("reduce_ranges") }
 
 #' @method reduce_ranges IntegerRanges
 #' @export
-reduce_ranges.IntegerRanges <- function(.data, ...) {
-  reduce_single(.data, ...)
+reduce_ranges.IntegerRanges <- function(.data, min.gapwidth = 1L, ...) {
+  reduce_single(.data, ..., 
+                rfun = function(x, ...) {
+                  reduce(x, ..., min.gapwidth = min.gapwidth)
+                })
 }
 
 #' @method reduce_ranges GroupedIntegerRanges
 #' @export
-reduce_ranges.GroupedIntegerRanges <- function(.data, ...) {
-  reduce_by_grp(.data, ...)
+reduce_ranges.GroupedIntegerRanges <- function(.data, min.gapwidth = 1L, ...) {
+  reduce_by_grp(.data, ..., 
+                rfun = function(x, ...) {
+                  reduce(x, ..., min.gapwidth = min.gapwidth)
+                })
 }
-
 
 #' @method reduce_ranges GroupedGenomicRanges
 #' @export
-reduce_ranges.GroupedGenomicRanges <- function(.data, ...) {
+reduce_ranges.GroupedGenomicRanges <- function(.data, min.gapwidth = 1L, ...) {
   reduce_by_grp(.data, ..., 
                 rfun = function(x, ...) {
-                  reduce(x, ..., ignore.strand = TRUE)
+                  reduce(x, ..., min.gapwidth = min.gapwidth, ignore.strand = TRUE)
                   })
 }
 
 #' @method reduce_ranges GenomicRanges
 #' @export
-reduce_ranges.GenomicRanges <- function(.data, ...) {
+reduce_ranges.GenomicRanges <- function(.data, min.gapwidth = 1L, ...) {
   reduce_single(.data, ..., 
                 rfun = function(x, ...) {
-                  reduce(x, ..., ignore.strand = TRUE)
+                  reduce(x, ..., min.gapwidth = min.gapwidth, ignore.strand = TRUE)
                 })
 }
 
 #' @rdname ranges-reduce
 #' @export
-reduce_ranges_directed <- function(.data, ...) {
+reduce_ranges_directed <- function(.data, min.gapwidth = 1L, ...) {
   UseMethod("reduce_ranges_directed")
 }
 
 #' @importFrom IRanges reduce
 #' @method reduce_ranges_directed GenomicRanges
 #' @export
-reduce_ranges_directed.GenomicRanges <- function(.data, ...) {
+reduce_ranges_directed.GenomicRanges <- function(.data, min.gapwidth = 1L, ...) {
   reduce_single(.data, ..., 
                 rfun = function(x, ...) {
-                  reduce(x, ..., ignore.strand = FALSE)
+                  reduce(x, ..., min.gapwidth = min.gapwidth, ignore.strand = FALSE)
                 })
 }
 
 #' @method reduce_ranges_directed GroupedGenomicRanges
 #' @export
-reduce_ranges_directed.GroupedGenomicRanges <- function(.data, ...) {
+reduce_ranges_directed.GroupedGenomicRanges <- function(.data, min.gapwidth = 1L, ...) {
   reduce_by_grp(.data, ..., 
                 rfun = function(x, ...) {
-                  reduce(x, ..., ignore.strand = FALSE)
+                  reduce(x, ..., min.gapwidth = min.gapwidth, ignore.strand = FALSE)
                 })
 }

--- a/man/overscope_ranges.Rd
+++ b/man/overscope_ranges.Rd
@@ -21,5 +21,5 @@ Create an overscoped environment from a Ranges object
 This is the backend for non-standard evaluation in \code{plyranges}.
 }
 \seealso{
-\code{\link[rlang:new_data_mask]{rlang::new_data_mask()}}, \code{\link[rlang:eval_tidy]{rlang::eval_tidy()}}
+\code{\link[rlang:as_data_mask]{rlang::new_data_mask()}}, \code{\link[rlang:eval_tidy]{rlang::eval_tidy()}}
 }

--- a/man/plyranges-package.Rd
+++ b/man/plyranges-package.Rd
@@ -44,7 +44,7 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Stuart Lee \email{lee.s@wehi.edu.au} (\href{https://orcid.org/0000-0003-1179-8436}{ORCID})
+\strong{Maintainer}: Stuart Lee \email{stuart.andrew.lee@gmail.com} (\href{https://orcid.org/0000-0003-1179-8436}{ORCID})
 
 Authors:
 \itemize{

--- a/man/ranges-info.Rd
+++ b/man/ranges-info.Rd
@@ -70,5 +70,5 @@ if (interactive()) {
 
 }
 \seealso{
-\code{\link[GenomeInfoDb:Seqinfo]{GenomeInfoDb::Seqinfo()}}
+\code{\link[GenomeInfoDb:Seqinfo-class]{GenomeInfoDb::Seqinfo()}}
 }

--- a/man/ranges-info.Rd
+++ b/man/ranges-info.Rd
@@ -25,9 +25,7 @@ set_genome_info(
 get_genome_info(.data)
 }
 \arguments{
-\item{genome}{A character vector of length one indicating the genome build.
-If this is the only argument supplied, the build information will be
-retrieved from UCSC database.}
+\item{genome}{A character vector of length one indicating the genome build.}
 
 \item{seqnames}{A character vector containing the name of sequences.}
 
@@ -43,8 +41,7 @@ as a Ranges object use \code{get_genome_info}.
 }
 \description{
 To construct annotations by supplying annotation information
-use \code{genome_info}. This function allows you to get UCSC build information
-via \code{\link[GenomeInfoDb:fetchExtendedChromInfoFromUCSC]{GenomeInfoDb::fetchExtendedChromInfoFromUCSC()}}. To add
+use \code{genome_info}. To add
 annotations to an existing Ranges object use \code{set_genome_info}. To retrieve
 an annotation as a Ranges object use \code{get_genome_info}.
 }
@@ -73,5 +70,5 @@ if (interactive()) {
 
 }
 \seealso{
-\code{\link[GenomeInfoDb:Seqinfo]{GenomeInfoDb::Seqinfo()}}, \code{\link[GenomeInfoDb:fetchExtendedChromInfoFromUCSC]{GenomeInfoDb::fetchExtendedChromInfoFromUCSC()}}
+\code{\link[GenomeInfoDb:Seqinfo]{GenomeInfoDb::Seqinfo()}}
 }

--- a/man/ranges-reduce.Rd
+++ b/man/ranges-reduce.Rd
@@ -5,12 +5,14 @@
 \alias{reduce_ranges_directed}
 \title{Reduce then aggregate a Ranges object}
 \usage{
-reduce_ranges(.data, ...)
+reduce_ranges(.data, min.gapwidth = 1L, ...)
 
-reduce_ranges_directed(.data, ...)
+reduce_ranges_directed(.data, min.gapwidth = 1L, ...)
 }
 \arguments{
 \item{.data}{a Ranges object to reduce}
+
+\item{min.gapwidth}{Ranges separated by a gap of at least min.gapwidth positions are not merged.}
 
 \item{...}{Name-value pairs of summary functions.}
 }

--- a/man/tidyverse-reexports.Rd
+++ b/man/tidyverse-reexports.Rd
@@ -24,10 +24,10 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{dplyr}{\code{\link[dplyr]{arrange}}, \code{\link[dplyr]{filter}}, \code{\link[dplyr]{group_by}}, \code{\link[dplyr]{group_vars}}, \code{\link[dplyr]{groups}}, \code{\link[dplyr]{mutate}}, \code{\link[dplyr]{select}}, \code{\link[dplyr]{slice}}, \code{\link[dplyr]{summarise}}, \code{\link[dplyr]{summarize}}, \code{\link[dplyr]{ungroup}}}
+  \item{dplyr}{\code{\link[dplyr]{arrange}}, \code{\link[dplyr]{filter}}, \code{\link[dplyr]{group_by}}, \code{\link[dplyr:group_data]{group_vars}}, \code{\link[dplyr:group_data]{groups}}, \code{\link[dplyr]{mutate}}, \code{\link[dplyr]{select}}, \code{\link[dplyr]{slice}}, \code{\link[dplyr]{summarise}}, \code{\link[dplyr:summarise]{summarize}}, \code{\link[dplyr:group_by]{ungroup}}}
 
-  \item{magrittr}{\code{\link[magrittr]{\%>\%}}}
+  \item{magrittr}{\code{\link[magrittr:pipe]{\%>\%}}}
 
-  \item{rlang}{\code{\link[rlang]{!!}}, \code{\link[rlang]{!!!}}}
+  \item{rlang}{\code{\link[rlang:injection-operator]{!!}}, \code{\link[rlang:splice-operator]{!!!}}}
 }}
 


### PR DESCRIPTION
plyranges currently has a WARNING in devel and release based upon a man page link:

http://bioconductor.org/checkResults/devel/bioc-LATEST/plyranges/

Note that the exported function name has changed in GenomeInfoDb:

https://github.com/Bioconductor/GenomeInfoDb/blob/master/NAMESPACE

But generally things are changing so it's not always UCSC that is used to build the seq info.

Here I manually updated the man pages instead of using roxygen, you may want to re-run on your end.